### PR TITLE
Make timeSinceLastRender protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **[FEATURE]** (`ktx-app`) Added `color` factory method to allow constructing LibGDX `Color` instances with named parameters.
 - **[FEATURE]** (`ktx-app`) Added `Color.copy` extension method that allows to copy `Color` instances with optional
 overriding of chosen values.
+- **[CHANGE]** (`ktx-app`) `KotlinApplication#timeSinceLastRender` now has a protected default getter.
 - **[CHANGE]** (`ktx-assets`) Static `AssetManager` instance container was deprecated. Static access to `AssetManager`
 will be removed in the next release.
 - **[FEATURE]** (`ktx-assets`) Added `load`, `loadAsset`, `loadOnDemand`, `getAsset`, `unload` and `unloadSafety`

--- a/app/src/main/kotlin/ktx/app/application.kt
+++ b/app/src/main/kotlin/ktx/app/application.kt
@@ -15,7 +15,8 @@ import com.badlogic.gdx.InputProcessor
  */
 abstract class KotlinApplication(protected val fixedTimeStep: Float = 1f / 60f,
                                  protected val maxDeltaTime: Float = 1f) : ApplicationListener {
-  private var timeSinceLastRender = 0f
+  protected var timeSinceLastRender = 0f
+                private set
 
   override fun resize(width: Int, height: Int) {
   }


### PR DESCRIPTION
As issue #54 states, it's a useful information for the user. e.g. interpolation/extrapolation between frames.